### PR TITLE
Slurm and singularity gpu docs

### DIFF
--- a/docs/src/landing_zone_docker.rst
+++ b/docs/src/landing_zone_docker.rst
@@ -5,6 +5,9 @@ Quickstart for Galileo Landing Zones and Docker
 The following is a user guide for deploying a Galileo Landing Zone
 (LZ) using our official Docker image.
 
+.. contents:: :local:
+	 :depth: 2
+
 Prerequisites
 -------------
 Docker must be installed on the machine you wish to use as a landing

--- a/docs/src/landing_zone_main.rst
+++ b/docs/src/landing_zone_main.rst
@@ -21,7 +21,7 @@ Getting Started
 
 We suggest that you use our officially supported Docker image to run
 an LZ. The LZ has experimental support for running from inside a
-Singularity container and in a SLURM cluster. Choose the link that
+Singularity container and in a Slurm cluster. Choose the link that
 fits your needs to find installation and execution instructions.
 
 .. toctree::
@@ -29,7 +29,7 @@ fits your needs to find installation and execution instructions.
 
     Docker <landing_zone_docker.rst>
     Singularity <landing_zone_singularity.rst>
-    SLURM <landing_zone_slurm.rst>
+    Slurm <landing_zone_slurm.rst>
 
 How It Works
 ------------

--- a/docs/src/landing_zone_singularity.rst
+++ b/docs/src/landing_zone_singularity.rst
@@ -142,3 +142,17 @@ you can prove this by running ``singularity instance list``.
     $ singularity instance stop landing-zone-daemon
 
 Singularity will automatically clean up the container used to run the instance.
+
+GPUs
+----
+Unfortunately GPU access is not supported by Galileo for Singularity
+at this time. This is because Singularity cannot give containers
+*exclusive* access to specific GPUs making that resource impossible to
+allocate fairly to Galileo jobs. We are experimenting with ways to
+work around this limitation, so if it directly impacts you please let
+us know!
+
+Galileo uses Singularity containers to run jobs on Slurm clusters, but
+Slurm has its own GPU constraint mechanisms that allow Galileo to
+support GPUs on those clusters. You can read more
+:ref:`here<slurm_gpus>`.

--- a/docs/src/landing_zone_singularity.rst
+++ b/docs/src/landing_zone_singularity.rst
@@ -6,6 +6,9 @@ Quickstart for Galileo Landing Zones and Singularity
 The following is a user guide for deploying a Galileo Landing Zone
 (LZ) using our official Singularity image.
 
+.. contents:: :local:
+	 :depth: 2
+
 Prerequisites
 -------------
 

--- a/docs/src/landing_zone_slurm.rst
+++ b/docs/src/landing_zone_slurm.rst
@@ -6,6 +6,9 @@ Quickstart for Galileo Landing Zones and Slurm
 The following is a user guide for deploying a Galileo Landing Zone
 (LZ) in a Slurm cluster.
 
+.. contents:: :local:
+	 :depth: 2
+
 Prerequisites
 -------------
 A Slurm client must be installed on the machine you wish to use as a

--- a/docs/src/landing_zone_slurm.rst
+++ b/docs/src/landing_zone_slurm.rst
@@ -27,6 +27,10 @@ file system that is readable and writable by every node in the
 cluster. You can override this location by setting the ``$TMPDIR``,
 ``$TEMP``, or ``$TMP`` environment variables.
 
+Admins should read through the `Slurm Configuration`_ documentation to
+make sure memory, CPUs, and GPUs are allocated to jobs in mutually
+exclusive ways.
+
 How It Works
 ------------
 The Galileo Landing Zone naturally lends itself to a clustered
@@ -64,6 +68,99 @@ Landing Zone as a job to the cluster, a user need only wait in the
 cluster queue once; thereafter they can skip the cluster's queue and 
 submit jobs directly to the LZ! Landing Zones in this circumstance will 
 be running in a :ref:`Singularity configuration <landing_zone_singularity>`.
+
+Slurm Configuration
+-------------------
+
+Memory
+~~~~~~
+
+Ensuring that Slurm jobs are constrained to the memory limits set in
+Galileo requires the memory and memsw (swap) cgroups. The `Slurm docs
+<https://slurm.schedmd.com/cgroups.html>`_ have an important note
+about these cgroups:
+
+    Debian and derivatives (e.g. Ubuntu) usually exclude the memory and
+    memsw (swap) cgroups by default. To include them, add the following
+    parameters to the kernel command line:
+    ``cgroup_enable=memory swapaccount=1``
+    This can usually be placed in /etc/default/grub inside the
+    *GRUB_CMDLINE_LINUX* variable. A command such as *update-grub* must be run
+    after updating the file.
+
+Next you must tell Slurm to use cgroups for its task management
+services. In slurm.conf make sure the task plugin is
+``TaskPlugin=task/cgroup`` and that the select type parameters
+includes memory, e.g.  ``SelectTypeParameters=CR_Core_Memory``.  Any
+of ``CR_Core_Memory``, ``CR_CPU_Memory``, or ``CR_Socket_Memory`` will
+work; consult the slurm.conf `man page
+<https://slurm.schedmd.com/slurm.conf.html>`_ to make a decision. Bear
+in mind the *CPU* settings in Galileo get translated to ``srun ... -n
+<cpus>`` on the cluster. ``CR_Memory`` is discouraged since Galileo
+does attempt to set constraints on CPU/core usage.
+
+Finally make sure that the cgroups are configured to enforce this
+constraint in cgroup.conf.
+
+.. code-block:: bash
+
+   ConstrainRAMSpace=yes
+   ConstrainSwapSpace=yes
+
+CPUs/Cores
+~~~~~~~~~~
+Slurm does not always use the words "CPU" and "Core" consistently in
+their documentation. The definitions might even shift from one Slurm
+configuration to another.
+
+To add to the confusion Galileo has its own concept of CPU settings
+that can be set in Mission and Job settings. This value gets
+translated into Slurm flags one of two ways, depending on whether the
+job requires distributed memory or not.
+
+Non-distributed jobs translate the value into these flags
+
+.. code-block:: bash
+
+    --ntasks 1  --cpus-per-task <cpus>
+
+Distributed jobs assume a one CPU default for tasks and translate
+the value into these flags
+
+.. code-block:: bash
+
+    --ntasks <cpus>
+
+How those flags affect actual hardware usage depends on your Slurm
+configuration. In particular, in *slurm.conf*, the value of
+``SelectTypeParameters`` may be either ``CR_Core_Memory``,
+``CR_CPU_Memory``, or ``CR_Socket_Memory`` (``CR_<x>_Memory`` is
+required for enforcing Galileo's memory constraints). Admins should
+refer to the `slurm.conf man page
+<https://slurm.schedmd.com/slurm.conf.html>`_ to investigate the
+hardware implications of each of these.
+
+As noted in our `Memory`_ section, we
+recommend ``task/cgroup`` for the value of ``TaskPlugin``. If that is
+the case, then we need to ensure the cgroup enforces the core
+constraints in cgroup.conf with ``ConstrainCores=yes``. It is also
+advisable to set ``TaskAffinity=yes`` in cgroup.conf to ensure tasks
+are bound to their allocated cores.
+
+.. _slurm_gpus:
+
+GPUS
+~~~~
+
+Galileo's support for GPU management in Slurm clusters hinges on the
+``select/cons_tres`` plugin introduced in Slurm version 19.05. Admins
+should consult the `Slurm documentation
+<https://slurm.schedmd.com/gres.html>`_ for correctly configuring this
+feature. To ensure that jobs receive exclusive access to the GPUs
+alloted to them, and only those GPUs, ``TaskPlugin`` should be set to
+``task/cgroup`` in slurm.conf and ``ConstrainDevices=yes`` should be
+included in cgroup.conf. See the `Memory`_ and `CPUs/Cores`_ sections
+for more considerations regarding ``task/cgroup``.
 
 How to Run the Landing Zone Daemon
 ----------------------------------

--- a/docs/src/landing_zone_slurm.rst
+++ b/docs/src/landing_zone_slurm.rst
@@ -1,15 +1,14 @@
 .. _landing_zone_slurm:
 
-Quickstart for Galileo Landing Zones and SLURM
+Quickstart for Galileo Landing Zones and Slurm
 ==============================================
 
 The following is a user guide for deploying a Galileo Landing Zone
-(LZ) in a SLURM cluster.
+(LZ) in a Slurm cluster.
 
 Prerequisites
 -------------
-
-A SLURM client must be installed on the machine you wish to use as a
+A Slurm client must be installed on the machine you wish to use as a
 Landing Zone. It must be configured to correctly run basic commands like
 ``srun`` and ``squeue``.
 
@@ -42,11 +41,11 @@ station queueing systems.
 As a Gateway
 ~~~~~~~~~~~~~~~
 
-The Landing Zone can be run on the headnode of a cluster and interact directly with its pre-existing SLURM resource scheduler.
+The Landing Zone can be run on the headnode of a cluster and interact directly with its pre-existing Slurm resource scheduler.
 
 .. image:: images/Galileo_HPC_gateway.png
 
-In the SLURM configuration the LZ receives the details of a job, builds 
+In the Slurm configuration the LZ receives the details of a job, builds
 a Singularity container for the job in ``/tmp``, and issues an ``srun`` 
 command to execute the container. Periodic calls to ``squeue`` and
 ``sstat`` are used to track the job's progress. When the job finishes


### PR DESCRIPTION
This has been split from the docker gpu docs so that we can release them separately if necessary.

This also includes nice localized content tables on all of the LZ pages and switches SLURM to Slurm, as per their own documents.