### PR TITLE
removed pandas pinning to 1.0.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if is_py3:
         "pyfiglet",
         "click",
         "click-shell",
-        "pandas==1.0.1",
+        "pandas",
         "halo",
         "curses-menu"
     ]


### PR DESCRIPTION
removed pinning on pandas dependency so that installing on windows doesn't require msvs build tools