### PR TITLE
Patch click/update docs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "venv\\Scripts\\python.exe"
+}

--- a/docs/src/landing_zone_main.rst
+++ b/docs/src/landing_zone_main.rst
@@ -52,11 +52,11 @@ downloads the files and data belonging to the job and uses them to
 construct a container according to the hardware specifications
 collected earlier. The LZ will then initiate the container's execution
 and respond to user requests to pause, unpause, and kill the job. When
-the container process has ended the LZ creates a zip archive of the
+the container process has ended, the LZ creates a zip archive of the
 process' stdout, stderr, and any new or changed files found in the
 ``/home/galileo`` directory. The LZ then uploads that archive to the
 Galileo service so that you can download it and get your results!
-Finally the LZ destroys anything it constructed to create the job
+Finally, the LZ destroys anything it constructed to create the job
 container and releases those resources back to its host.
 
 

--- a/docs/src/security.rst
+++ b/docs/src/security.rst
@@ -69,7 +69,7 @@ Galileo supports a suite of software and applications in the form of officially 
 Types. Software environments like Python, Julia, and R Language as well as interactive applications like
 Jupyter Notebooks, PCSWMM, and QGIS are officially supported and can be configured through the Mission
 Configuration Wizard. In all instances of Galileo-supported Mission Framework types, processes are executed
-with **non-root** priveledges as a security precaution. Additionally, users are not allowed to directly modify 
+with **non-root** privileges as a security precaution. Additionally, users are not allowed to directly modify 
 the Dockerfile created for them in their Mission context, only the Galileo service can write to this file using 
 the pre-configured rules assigned to the target software. 
 
@@ -102,7 +102,7 @@ structure is strictly controlled by the framework definition. If a user does pro
 Galileo identifies this Mission type as “user-defined.” 
 
 Within the context of a Mission, Galileo users can invite collaborators as role-based 
-members. The role assigned to a member determines if they read access to the input 
+members. The role assigned to a member determines if they have read access to the input 
 data and results data and if they have write/execute permission.
 
 Missions can be used in tandem with the `Cargo Bays <cargobays.html>`_ feature. During the configuration stage of a new Mission, if the user chooses a non-default Cargo Bay (like Dropbox), all input and result files will be stored in that storage resource, the data will not persist in Galileo-hosted resources. If you lose access to your third-party storage provider, Hypernet Labs will not be able to recover it. Deleting a Cargo Bay necessarily deactivates any Mission referencing that resource as a storage provider, but does not delete the data stored there. 

--- a/docs/src/stations.rst
+++ b/docs/src/stations.rst
@@ -74,7 +74,7 @@ Station administrators can expose `volumes <https://docs.docker.com/storage/volu
 * exposing networked filesystems 
 * sharing data between jobs running on the same LZ 
 
-When a volume is added to a Station, it will only be attached to jobs that where submitted to that specific Station. An LZ attached to multiple Stations will not expose volumes to a job if it is not associated with a Station that has been configured to have a volume.  
+When a volume is added to a Station, it will only be attached to jobs that were submitted to that specific Station. An LZ attached to multiple Stations will not expose volumes to a job if it is not associated with a Station that has been configured to have a volume.  
 
 A volume can be added to a Station by clicking the "VOLUMES" tab in the context of the relevant station. 
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if is_py3:
         "termcolor==1.1.0",
         "colorama==0.4.3",
         "pyfiglet",
-        "click",
+        "click==7.1.2",
         "click-shell",
         "pandas",
         "halo",


### PR DESCRIPTION
Pinned click dependency to 7.1.2, after click 8.0.0 conflicted with click-shell and broke the Galileo CLI.  Also fixed typos for the documentation. 