### PR TITLE
fix cli and add new helper script

### DIFF
--- a/docs/src/landing_zone_main.rst
+++ b/docs/src/landing_zone_main.rst
@@ -113,6 +113,14 @@ Command Line Flags
   location, then it will be utilized and the LZ will authenticate
   automatically without prompting the user.
 
+``--stations``   ``<COMMA SEPARATED LIST OF STATION IDS>``
+  At startup the Landing Zone will attempt to add itself to all of the
+  stations represented by the station ids provided to this flag. If an
+  attempt fails for any reason, then the Landing Zone will remain in
+  any stations it was successfully added to before the failure, it
+  will not attempt to add itself to any subsequent station ids in the
+  list, and the LZ will exit.
+
 .. _landing_zone_main-tunnnel-overrides:
 
 ``--cloudflare-cert <FILE PATH>`` and ``--tunnel-hostname <TEXT>``

--- a/galileo_sdk/galileo_cli/jobs.py
+++ b/galileo_sdk/galileo_cli/jobs.py
@@ -122,7 +122,7 @@ def jobs_cli(main, galileo: GalileoSdk):
         spinner = Halo("Retrieving information", spinner="dots").start()
 
         #Testing purpose
-        my_id = galileo.profiles.self().userid
+        my_id = galileo.profiles.self().user_id
         user_ids = list(user_ids) + [my_id]
         receiver_ids = list(receiver) + galileo.lz.list_lz(user_ids=[my_id])
         spinner.stop()

--- a/galileo_sdk/galileo_cli/lzs.py
+++ b/galileo_sdk/galileo_cli/lzs.py
@@ -38,13 +38,13 @@ def lzs_cli(main, galileo: GalileoSdk):
         spinner.start()
 
         self = galileo.profiles.self()
-        userids = []
+        user_ids = []
         if not everything:
-            userids.append(self.userid)
+            user_ids.append(self.user_id)
 
         lzs = galileo.lz.list_lz(
             lz_ids=list(lz_ids),
-            user_ids=list(userids),
+            user_ids=list(user_ids),
             page=page,
             items=items,
         )

--- a/galileo_sdk/galileo_cli/missions.py
+++ b/galileo_sdk/galileo_cli/missions.py
@@ -37,7 +37,7 @@ def missions_cli(main, galileo: GalileoSdk):
     )
     @click.option(
         "-u",
-        "--userid",
+        "--user_id",
         type=str,
         multiple=True,
         help="Filter by userids, can provide multiple options.",
@@ -52,7 +52,7 @@ def missions_cli(main, galileo: GalileoSdk):
                   '--head',
                   type=int,
                   help="Number of Missions to display.")
-    def ls(index, id, short, name, userid, page, items, head):
+    def ls(index, id, short, name, user_id, page, items, head):
         """
         List the Missions in your Galileo profile.
         """
@@ -60,11 +60,11 @@ def missions_cli(main, galileo: GalileoSdk):
         self = galileo.profiles.self()
         spinner.stop()
         spinner = Halo("Retrieving your Mission", spinner="dot").start()
-        userid += (self.userid, )
+        user_id += (self.user_id, )
         missions = galileo.missions.list_missions(
             mission_ids=list(id),
             names=list(name),
-            user_ids=list(userid),
+            user_ids=list(user_id),
             page=page,
             items=items,
         )

--- a/galileo_sdk/galileo_cli/profiles.py
+++ b/galileo_sdk/galileo_cli/profiles.py
@@ -43,13 +43,6 @@ def profiles_cli(main, galileo: GalileoSdk):
         multiple=True,
         help="Filter by partial usernames, can provide multiple options.",
     )
-    @click.option(
-        "-k",
-        "--publickey",
-        type=str,
-        multiple=True,
-        help="Filter by public key, can provide multiple options.",
-    )
     @click.option("--page", type=int, help="Filter by page number.")
     @click.option(
         "--items",
@@ -57,7 +50,7 @@ def profiles_cli(main, galileo: GalileoSdk):
         help="Filter by number of items in the page.",
     )
     @click.option('-n', '--head', type=int, help="Number of items to display.")
-    def ls(index, id, username, partialname, publickey, page, items, head):
+    def ls(index, id, username, partialname, page, items, head):
         """
         List of all the profiles.
         """
@@ -66,7 +59,6 @@ def profiles_cli(main, galileo: GalileoSdk):
             user_ids=list(id),
             usernames=list(username),
             partial_usernames=list(partialname),
-            public_keys=list(publickey),
             page=page,
             items=items,
         )
@@ -83,7 +75,7 @@ def profiles_cli(main, galileo: GalileoSdk):
 
         users_list = [user.__dict__ for user in users_list]
         users_df = pandas.json_normalize(users_list)
-        users_df = users_df[["username", "userid", "lz_ids"]]
+        users_df = users_df[["username", "user_id", "lz_ids"]]
 
         spinner.stop()
         if head:

--- a/galileo_sdk/galileo_cli/stations.py
+++ b/galileo_sdk/galileo_cli/stations.py
@@ -93,7 +93,7 @@ def stations_cli(main, galileo: GalileoSdk):
         stations_list = [station.__dict__ for station in stations_list]
         stations_df = pandas.json_normalize(stations_list)
         stations_df = stations_df[[
-            "stationid", "name", "description", "users", "lz_ids", "volumes"
+            "station_id", "name", "description", "users", "lz_ids", "volumes"
         ]]
         spinner.stop()
         click.echo(stations_df)

--- a/galileo_sdk/galileo_sdk.py
+++ b/galileo_sdk/galileo_sdk.py
@@ -45,6 +45,13 @@ if is_py3:
 NAMESPACE = "/galileo/user_interface/v1"
 
 
+def notify():
+    if len(sys.argv) > 1:
+        GalileoSdk.send_notification(GalileoSdk, sys.argv[1])
+    else:
+        print("No message given for notification.")
+
+
 class GalileoSdk:
     def __init__(
         self,

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup
 from setuptools.command.install import install
 
-VERSION = "1.0.0"
+VERSION = "1.0.1"
 
 _ver = sys.version_info
 

--- a/setup.py
+++ b/setup.py
@@ -13,20 +13,10 @@ is_py3 = _ver[0] == 3
 
 if is_py3:
     install_requires = [
-        "requests>=2.21.0",
-        "python-socketio[client]==4.3.1",
-        "python-engineio==3.9.0",
-        "chardet",
-        "mock",
-        "pathlib",
-        "termcolor==1.1.0",
-        "colorama==0.4.3",
-        "pyfiglet",
-        "click==7.1.2",
-        "click-shell",
-        "pandas",
-        "halo",
-        "curses-menu"
+        "requests>=2.21.0", "python-socketio[client]==4.3.1",
+        "python-engineio==3.9.0", "chardet", "mock", "pathlib",
+        "termcolor==1.1.0", "colorama==0.4.3", "pyfiglet", "click==7.1.2",
+        "click-shell", "pandas", "halo", "curses-menu"
     ]
 else:
     install_requires = [
@@ -46,8 +36,7 @@ class VerifyVersionCommand(install):
 
         if tag != VERSION:
             info = "Git tag: {0} does not match the version of this app: {1}".format(
-                tag, VERSION
-            )
+                tag, VERSION)
             sys.exit(info)
 
 
@@ -57,7 +46,8 @@ setup(
     license="MIT",
     author="Hypernet Labs",
     author_email="galileo@hypernetlabs.io",
-    long_description="Galileo is a hub for modeling, simulations, and data analysis that functions as a quick and "
+    long_description=
+    "Galileo is a hub for modeling, simulations, and data analysis that functions as a quick and "
     "easy portal to cloud resources.  The application streamlines computing infrastructure, "
     "saving engineers and researchers weeks of cloud setup time.  Team and station features allow "
     "teams to collaborate efficiently by sharing projects and results, flexibly controlling "
@@ -67,7 +57,12 @@ setup(
     "jobs, accepting jobs, and accepting members.",
     url="https://hypernetlabs.io/galileo/",
     packages=["galileo_sdk"],
-    entry_points={"console_scripts": ["galileo-cli = galileo_sdk.galileo_cli.cli:main",]},
+    entry_points={
+        "console_scripts": [
+            "galileo-cli = galileo_sdk.galileo_cli.cli:main",
+            "galileo-notify = galileo_sdk.galileo_sdk:notify"
+        ]
+    },
     package_data={
         "galileo_sdk": [
             "sdk/**",
@@ -85,5 +80,7 @@ setup(
     install_requires=install_requires,
     extras_require={"docs": ["sphinx>=2.2.0", "sphinx-material"]},
     tests_require=["pytest-runner", "pytest"],
-    cmdclass={"verify": VerifyVersionCommand,},
+    cmdclass={
+        "verify": VerifyVersionCommand,
+    },
 )


### PR DESCRIPTION
cli was broken from migration to new naming scheme. Also added new script, alongside galileo-cli, called galileo-notify. This can be used to send job notifications without the need to generate an sdk auth token. 